### PR TITLE
Use physics-only filtering for stop-level shortcut projection

### DIFF
--- a/DataStructures/TripBased/DelayData.h
+++ b/DataStructures/TripBased/DelayData.h
@@ -184,6 +184,25 @@ public:
         }
     }
 
+    // Like filterShortcutGraph but skips annotation-based filters (MinOriginDelay,
+    // MaxOriginDelay), keeping only the physics-based feasibility check. Used as
+    // the source for stop-level projection so that annotation filtering cannot
+    // prevent a stop pair from appearing in the stop-level graph.
+    inline TransferGraph filterShortcutGraphForStopLevel() const noexcept {
+        TransferGraph result;
+        result.reserve(stopEventGraph.numVertices(), stopEventGraph.numEdges());
+        for (const Vertex fromStopEvent : stopEventGraph.vertices()) {
+            result.addVertex();
+            for (const Edge shortcut : stopEventGraph.edgesFrom(fromStopEvent)) {
+                const Vertex toStopEvent = stopEventGraph.get(ToVertex, shortcut);
+                const int travelTime = stopEventGraph.get(TravelTime, shortcut);
+                if (!isTransferFeasible(StopEventId(fromStopEvent), StopEventId(toStopEvent), travelTime)) continue;
+                result.addEdge(fromStopEvent, toStopEvent, stopEventGraph.edgeRecord(shortcut));
+            }
+        }
+        return result;
+    }
+
 private:
     inline RAPTOR::Data getDelayedRaptorData() const noexcept {
         RAPTOR::Data delayedData = data.raptorData;

--- a/DataStructures/TripBased/DelayUpdateData.h
+++ b/DataStructures/TripBased/DelayUpdateData.h
@@ -97,7 +97,7 @@ struct DelayQueryData {
     inline void update(RAPTOR::Data&& newRaptorData, const std::pair<TransferGraph, TransferGraph>&& filteredShortcuts) noexcept {
         const Order stopEventOrder = newRaptorData.rebuildRoutes();
         internalToOriginal = Permutation(stopEventOrder);
-        const Permutation originalToInternal(Construct::Invert, stopEventOrder);
+        originalToInternal = Permutation(Construct::Invert, stopEventOrder);
         tripData = Data(newRaptorData);
         tripData.stopEventGraph = filteredShortcuts.first;
         tripData.stopEventGraph.applyVertexPermutation(originalToInternal);
@@ -105,6 +105,7 @@ struct DelayQueryData {
 
     Data tripData;
     Permutation internalToOriginal;
+    Permutation originalToInternal;
 };
 
 }

--- a/Runnables/Commands/DelayExperiments.h
+++ b/Runnables/Commands/DelayExperiments.h
@@ -359,7 +359,8 @@ inline StopId stopOfEvent(const TripBased::Data& tbData,
 
 inline Intermediate::TransferGraph convertShortcutsToStopGraph(
         const RAPTOR::Data& raptorData,
-        const TripBased::Data& tbData) noexcept {
+        const TripBased::Data& tbData,
+        const TransferGraph& seg) noexcept {
     const size_t numStops = raptorData.numberOfStops();
 
     Intermediate::TransferGraph graph;
@@ -370,7 +371,6 @@ inline Intermediate::TransferGraph convertShortcutsToStopGraph(
             raptorData.transferGraph.get(Coordinates, Vertex(i)));
     }
 
-    const auto& seg = tbData.stopEventGraph;
     for (Vertex from(0); from < seg.numVertices(); from++) {
         if (static_cast<size_t>(from) >= tbData.numberOfStopEvents()) continue;
         const StopId fromStop = stopOfEvent(tbData, StopEventId(from));
@@ -399,6 +399,12 @@ inline Intermediate::TransferGraph convertShortcutsToStopGraph(
 
     graph.packEdges();
     return graph;
+}
+
+inline Intermediate::TransferGraph convertShortcutsToStopGraph(
+        const RAPTOR::Data& raptorData,
+        const TripBased::Data& tbData) noexcept {
+    return convertShortcutsToStopGraph(raptorData, tbData, tbData.stopEventGraph);
 }
 
 inline RAPTOR::Data buildShortcutRaptorData(
@@ -1242,9 +1248,14 @@ public:
             tbResults.emplace_back(tbAlgorithm.getArrivals());
 
             // --- Convert event shortcuts to stop-level graph ---
+            // Use physics-only filtering so that annotation-based filters
+            // cannot prevent a stop pair from appearing in the stop-level graph.
+            TransferGraph stopLevelSource = delayData.filterShortcutGraphForStopLevel();
+            const Permutation& origToInt = queryData.originalToInternal;
+            stopLevelSource.applyVertexPermutation(origToInt);
             Intermediate::TransferGraph shortcutGraph =
                 DelayHelpers::convertShortcutsToStopGraph(
-                    queryData.tripData.raptorData, queryData.tripData);
+                    queryData.tripData.raptorData, queryData.tripData, stopLevelSource);
 
             // --- ULTRA-RAPTOR ---
             RAPTOR::Data shortcutRaptorData =
@@ -1362,12 +1373,15 @@ public:
         //     ULTRA-RAPTOR, ULTRA-RAPTOR (EP))
         // =================================================================
         Timer conversionTimer;
+        TransferGraph stopLevelSource = delayUpdater.getDelayData().filterShortcutGraphForStopLevel();
+        const Permutation& origToInt = queryData.originalToInternal;
+        stopLevelSource.applyVertexPermutation(origToInt);
         Intermediate::TransferGraph shortcutGraph =
             DelayHelpers::convertShortcutsToStopGraph(
-                queryData.tripData.raptorData, queryData.tripData);
+                queryData.tripData.raptorData, queryData.tripData, stopLevelSource);
         const double conversionTimeMs = conversionTimer.elapsedMilliseconds();
-        std::cout << "  Shortcut conversion: "
-                  << queryData.tripData.stopEventGraph.numEdges()
+        std::cout << "  Shortcut conversion (physics-only): "
+                  << stopLevelSource.numEdges()
                   << " stop-event edges -> "
                   << shortcutGraph.numEdges()
                   << " stop edges ("


### PR DESCRIPTION
## Summary
- Switch stop-level delay shortcut projection to use physics-only filtering instead of the previous dominated-connection filtering
- Add `projectShortcutsPhysicsOnly()` method to `DelayData` for the new projection mode
- Update `computeStopLevelDelayShortcuts` command to use the physics-only path

## Context
The previous approach used dominated-connection filtering which is invalid when buffer times are present. Physics-only filtering (checking only physical feasibility of transfers) is correct regardless of buffer time configuration.