### PR TITLE
Add hub label baselines and lviennot HL import/export

### DIFF
--- a/Algorithms/CH/HubLabelExtractor.h
+++ b/Algorithms/CH/HubLabelExtractor.h
@@ -1,0 +1,250 @@
+#pragma once
+
+#include <algorithm>
+#include <iostream>
+#include <queue>
+#include <vector>
+
+#include "CH.h"
+#include "CHUtils.h"
+
+#include "../../DataStructures/Graph/Graph.h"
+#include "../../Helpers/Console/Progress.h"
+#include "../../Helpers/String/String.h"
+#include "../../Helpers/Timer.h"
+#include "../../Helpers/Types.h"
+
+namespace CH {
+
+// Extracts minimal (pruned) hub labels from a Contraction Hierarchy.
+//
+// Uses the standard pruned labeling algorithm: vertices are processed from
+// highest to lowest CH rank. For each vertex v, an upward Dijkstra is run
+// in the CH, but a hub h is only added to v's label if the existing labels
+// cannot yet cover the v-to-h shortest distance (2-hop pruning).
+//
+// Forward labels use ch.forward, backward labels use ch.backward.
+// Both directions are built together per vertex to satisfy the pruning
+// dependency (forward pruning needs backward labels, and vice versa).
+//
+// Requires a full CH (no core vertices). A Core CH will produce incorrect labels.
+class HubLabelExtractor {
+
+    struct HubEntry {
+        Vertex hub;
+        int distance;
+    };
+
+    using Label = std::vector<HubEntry>;
+
+public:
+    HubLabelExtractor(const CH& ch) :
+        ch(ch),
+        numVertices(ch.numVertices()),
+        forwardLabels(ch.numVertices()),
+        backwardLabels(ch.numVertices()) {
+    }
+
+    void run() {
+        Timer timer;
+
+        std::cout << "Computing processing order..." << std::endl;
+        timer.restart();
+        const std::vector<Vertex> order = computeProcessingOrder();
+        std::cout << "  Done in " << String::msToString(timer.elapsedMilliseconds()) << std::endl;
+
+        std::cout << "Extracting pruned hub labels..." << std::endl;
+        timer.restart();
+        extractPrunedLabels(order);
+        std::cout << "  Done in " << String::msToString(timer.elapsedMilliseconds()) << std::endl;
+
+        std::cout << "Building TransferGraphs..." << std::endl;
+        timer.restart();
+        buildGraph(forwardLabels, outHubs);
+        buildGraph(backwardLabels, inHubs);
+        std::cout << "  Done in " << String::msToString(timer.elapsedMilliseconds()) << std::endl;
+
+        printStatistics();
+    }
+
+    TransferGraph& getOutHubs() noexcept { return outHubs; }
+    TransferGraph& getInHubs() noexcept { return inHubs; }
+    const TransferGraph& getOutHubs() const noexcept { return outHubs; }
+    const TransferGraph& getInHubs() const noexcept { return inHubs; }
+
+private:
+    // Returns vertices in processing order: highest CH rank first.
+    // CH::getOrder() returns contraction order (lowest rank first), so we reverse.
+    std::vector<Vertex> computeProcessingOrder() const {
+        std::vector<Vertex> order = getOrder(ch);
+        std::reverse(order.begin(), order.end());
+        return order;
+    }
+
+    void extractPrunedLabels(const std::vector<Vertex> &order) {
+        size_t totalForward = 0;
+        size_t totalBackward = 0;
+
+        Progress progress(numVertices);
+        for (const Vertex v : order) {
+            // Self-entry: every vertex is its own hub at distance 0
+            forwardLabels[v].push_back({v, 0});
+            backwardLabels[v].push_back({v, 0});
+
+            // Build forward label (upward search in ch.forward)
+            prunedUpwardSearch(v, ch.forward, forwardLabels, backwardLabels);
+
+            // Build backward label (upward search in ch.backward)
+            prunedUpwardSearch(v, ch.backward, backwardLabels, forwardLabels);
+
+            // Sort both labels by hub vertex ID for efficient merge-queries
+            sortLabel(forwardLabels[v]);
+            sortLabel(backwardLabels[v]);
+
+            totalForward += forwardLabels[v].size();
+            totalBackward += backwardLabels[v].size();
+
+            progress++;
+        }
+
+        std::cout << "  Forward labels: " << String::prettyInt(totalForward)
+                  << " entries (avg " << String::prettyDouble(static_cast<double>(totalForward) / numVertices, 1) << ")" << std::endl;
+        std::cout << "  Backward labels: " << String::prettyInt(totalBackward)
+                  << " entries (avg " << String::prettyDouble(static_cast<double>(totalBackward) / numVertices, 1) << ")" << std::endl;
+    }
+
+    // Runs a pruned upward Dijkstra from vertex v in the given CH graph.
+    // myLabels[v] is being built (has self-entry already).
+    // otherLabels contains the completed labels in the OTHER direction
+    // for all higher-ranked vertices (used for the pruning check).
+    void prunedUpwardSearch(const Vertex v, const CHGraph& graph,
+                            std::vector<Label>& myLabels,
+                            const std::vector<Label>& otherLabels) {
+        using QueueEntry = std::pair<int, Vertex>;
+        // Thread-unsafe but single-threaded: reuse across calls
+        static std::priority_queue<QueueEntry, std::vector<QueueEntry>, std::greater<>> pq;
+        static std::vector<int> distance;
+        static std::vector<Vertex> touched;
+
+        if (distance.size() < numVertices) {
+            distance.assign(numVertices, INFTY);
+            touched.reserve(512);
+        }
+
+        // Seed with upward neighbors of v
+        for (const Edge edge : graph.edgesFrom(v)) {
+            const Vertex w = graph.get(ToVertex, edge);
+            const int d = graph.get(Weight, edge);
+            if (d < distance[w]) {
+                if (distance[w] == INFTY) touched.push_back(w);
+                distance[w] = d;
+                pq.push({d, w});
+            }
+        }
+
+        while (!pq.empty()) {
+            const auto [dist, u] = pq.top();
+            pq.pop();
+
+            if (dist > distance[u]) continue;
+
+            // Pruning check: is v->u already covered by existing labels?
+            if (twoHopDistance(myLabels[v], otherLabels[u]) <= dist) {
+                // This hub (and its upward neighborhood) is redundant
+                continue;
+            }
+
+            // Hub u is necessary -- add to v's label
+            myLabels[v].push_back({u, dist});
+
+            // Relax upward edges
+            for (const Edge edge : graph.edgesFrom(u)) {
+                const Vertex w = graph.get(ToVertex, edge);
+                const int newDist = dist + graph.get(Weight, edge);
+                if (newDist < distance[w]) {
+                    if (distance[w] == INFTY) touched.push_back(w);
+                    distance[w] = newDist;
+                    pq.push({newDist, w});
+                }
+            }
+        }
+
+        // Reset touched vertices
+        for (const Vertex u : touched) {
+            distance[u] = INFTY;
+        }
+        touched.clear();
+    }
+
+    // Computes the 2-hop distance between the owners of labelA and labelB.
+    // labelA is being built (unsorted, small), labelB is already sorted by hub ID.
+    static int twoHopDistance(const Label& labelA, const Label& labelB) {
+        int result = INFTY;
+        for (const auto& [h, dh] : labelA) {
+            // Binary search for h in sorted labelB
+            auto it = std::lower_bound(labelB.begin(), labelB.end(), h,
+                [](const HubEntry& e, Vertex hub) { return e.hub < hub; });
+            if (it != labelB.end() && it->hub == h) {
+                const int candidate = dh + it->distance;
+                if (candidate < result) {
+                    result = candidate;
+                    if (result == 0) return 0;
+                }
+            }
+        }
+        return result;
+    }
+
+    static void sortLabel(Label& label) {
+        std::sort(label.begin(), label.end(),
+            [](const HubEntry& a, const HubEntry& b) { return a.hub < b.hub; });
+    }
+
+    void buildGraph(const std::vector<Label>& labels, TransferGraph& result) const {
+        DynamicTransferGraph dynamicGraph;
+        dynamicGraph.addVertices(numVertices);
+
+        for (size_t v = 0; v < numVertices; v++) {
+            for (const auto& [hub, dist] : labels[v]) {
+                if (Vertex(v) == hub) continue; // Skip self-entries for TransferGraph
+                dynamicGraph.addEdge(Vertex(v), hub).set(TravelTime, dist);
+            }
+        }
+
+        Graph::move(std::move(dynamicGraph), result);
+    }
+
+    void printStatistics() const {
+        std::cout << "\nHub label statistics:" << std::endl;
+        std::cout << "  Vertices:  " << String::prettyInt(numVertices) << std::endl;
+        std::cout << "  Out-hubs:  " << String::prettyInt(outHubs.numEdges()) << " edges" << std::endl;
+        std::cout << "  In-hubs:   " << String::prettyInt(inHubs.numEdges()) << " edges" << std::endl;
+
+        // Count unique hubs
+        std::vector<bool> isHub(numVertices, false);
+        for (const Vertex v : outHubs.vertices()) {
+            for (const Edge edge : outHubs.edgesFrom(v)) {
+                isHub[outHubs.get(ToVertex, edge)] = true;
+            }
+        }
+        for (const Vertex v : inHubs.vertices()) {
+            for (const Edge edge : inHubs.edgesFrom(v)) {
+                isHub[inHubs.get(ToVertex, edge)] = true;
+            }
+        }
+        size_t hubCount = 0;
+        for (size_t i = 0; i < numVertices; i++) {
+            if (isHub[i]) hubCount++;
+        }
+        std::cout << "  Unique hubs: " << String::prettyInt(hubCount) << std::endl;
+    }
+
+    const CH& ch;
+    const size_t numVertices;
+    std::vector<Label> forwardLabels;
+    std::vector<Label> backwardLabels;
+    TransferGraph outHubs;
+    TransferGraph inHubs;
+};
+
+}

--- a/Algorithms/RAPTOR/HLRAPTOR.h
+++ b/Algorithms/RAPTOR/HLRAPTOR.h
@@ -46,9 +46,12 @@ private:
 public:
     HLRAPTOR(const Data& data, const InitialTransferGraph& outHubGraph, const InitialTransferGraph& inHubGraph, const Profiler& profilerTemplate = Profiler()) :
         data(data),
-        outHubs(outHubGraph),
-        inHubs(inHubGraph),
-        reverseInHubs(inHubGraph),
+        ownedOutHubs(outHubGraph),
+        ownedInHubs(inHubGraph),
+        ownedReverseInHubs(inHubGraph),
+        outHubs(ownedOutHubs),
+        inHubs(ownedInHubs),
+        reverseInHubs(ownedReverseInHubs),
         transferDistanceToTarget(inHubs.numVertices(), INFTY),
         hubParentLabels(inHubs.numVertices()),
         earliestArrival(inHubs.numVertices()),
@@ -67,17 +70,52 @@ public:
         profiler.registerPhases({PHASE_INITIALIZATION, PHASE_COLLECT, PHASE_SCAN, PHASE_TRANSFERS});
         profiler.registerMetrics({METRIC_ROUTES, METRIC_ROUTE_SEGMENTS, METRIC_VERTICES, METRIC_EDGES, METRIC_STOPS_BY_TRIP, METRIC_STOPS_BY_TRANSFER});
         profiler.initialize();
-        outHubs.sortEdges(TravelTime);
-        inHubs.sortEdges(TravelTime);
+        ownedOutHubs.sortEdges(TravelTime);
+        ownedInHubs.sortEdges(TravelTime);
+        buildReverseInHubs();
+    }
+
+    // Constructor referencing pre-built, pre-sorted hub data (zero-copy).
+    // Caller must ensure outHubsSorted, inHubsSorted, and reverseInHubsSorted
+    // are already sorted by TravelTime and outlive this HLRAPTOR instance.
+    HLRAPTOR(const Data& data, const TransferGraph& outHubsSorted, const TransferGraph& inHubsSorted, const TransferGraph& reverseInHubsSorted, const Profiler& profilerTemplate = Profiler()) :
+        data(data),
+        outHubs(outHubsSorted),
+        inHubs(inHubsSorted),
+        reverseInHubs(reverseInHubsSorted),
+        transferDistanceToTarget(inHubs.numVertices(), INFTY),
+        hubParentLabels(inHubs.numVertices()),
+        earliestArrival(inHubs.numVertices()),
+        stopsUpdatedByRoute(data.numberOfStops() + 1),
+        stopsUpdatedByTransfer(data.numberOfStops() + 1),
+        updatedHubs(inHubs.numVertices()),
+        routesServingUpdatedStops(data.numberOfRoutes()),
+        sourceVertex(noVertex),
+        targetVertex(noVertex),
+        targetStop(noStop),
+        lastTarget(Vertex(0)),
+        sourceDepartureTime(never),
+        profiler(profilerTemplate) {
+        Assert(data.hasImplicitBufferTimes(), "Departure buffer times have to be implicit!");
+        profiler.registerExtraRounds({EXTRA_ROUND_CLEAR, EXTRA_ROUND_INITIALIZATION});
+        profiler.registerPhases({PHASE_INITIALIZATION, PHASE_COLLECT, PHASE_SCAN, PHASE_TRANSFERS});
+        profiler.registerMetrics({METRIC_ROUTES, METRIC_ROUTE_SEGMENTS, METRIC_VERTICES, METRIC_EDGES, METRIC_STOPS_BY_TRIP, METRIC_STOPS_BY_TRANSFER});
+        profiler.initialize();
+    }
+
+    // Build reverseInHubs from inHubs (static helper for pre-building)
+    static TransferGraph buildReverseInHubs(const Data& data, const InitialTransferGraph& inHubGraph) {
+        TransferGraph result(inHubGraph);
         DynamicTransferGraph tempGraph;
-        Graph::copy(reverseInHubs, tempGraph);
+        Graph::copy(result, tempGraph);
         for (const Vertex vertex : tempGraph.vertices()) {
             if (data.isStop(vertex)) continue;
             tempGraph.deleteAllOutgoingEdges(vertex);
         }
         tempGraph.revert();
-        Graph::move(std::move(tempGraph), reverseInHubs);
-        reverseInHubs.sortEdges(TravelTime);
+        Graph::move(std::move(tempGraph), result);
+        result.sortEdges(TravelTime);
+        return result;
     }
 
     inline void run(const Vertex source, const int departureTime, const Vertex target, const size_t maxRounds = INFTY) noexcept {
@@ -436,11 +474,26 @@ private:
         labels.emplace_back(std::min(rounds[round][stop].arrivalTime, (labels.empty()) ? (never) : (labels.back())));
     }
 
+    void buildReverseInHubs() {
+        DynamicTransferGraph tempGraph;
+        Graph::copy(ownedReverseInHubs, tempGraph);
+        for (const Vertex vertex : tempGraph.vertices()) {
+            if (data.isStop(vertex)) continue;
+            tempGraph.deleteAllOutgoingEdges(vertex);
+        }
+        tempGraph.revert();
+        Graph::move(std::move(tempGraph), ownedReverseInHubs);
+        ownedReverseInHubs.sortEdges(TravelTime);
+    }
+
 private:
     const Data& data;
-    TransferGraph outHubs;
-    TransferGraph inHubs;
-    TransferGraph reverseInHubs;
+    TransferGraph ownedOutHubs;
+    TransferGraph ownedInHubs;
+    TransferGraph ownedReverseInHubs;
+    const TransferGraph& outHubs;
+    const TransferGraph& inHubs;
+    const TransferGraph& reverseInHubs;
 
     std::vector<int> transferDistanceToTarget;
 

--- a/DataStructures/Queries/Queries.h
+++ b/DataStructures/Queries/Queries.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <numeric>
 #include <random>
 #include <vector>
 
@@ -28,6 +30,20 @@ inline std::vector<VertexQuery> generateRandomVertexQueries(const size_t numVert
     std::vector<VertexQuery> queries;
     for (size_t i = 0; i < numQueries; i++) {
         queries.emplace_back(Vertex(vertexDistribution(randomGenerator)), Vertex(vertexDistribution(randomGenerator)), timeDistribution(randomGenerator));
+    }
+    return queries;
+}
+
+inline std::vector<VertexQuery> generateRandomVertexQueriesWithoutReplacement(const size_t numVertices, const size_t numQueries, const int startTime = 0, const int endTime = 24 * 60 * 60) noexcept {
+    Assert(2 * numQueries <= numVertices, "Need at least 2n vertices for n without-replacement queries!");
+    std::mt19937 randomGenerator(42);
+    std::uniform_int_distribution<> timeDistribution(startTime, endTime - 1);
+    std::vector<size_t> perm(numVertices);
+    std::iota(perm.begin(), perm.end(), 0);
+    std::shuffle(perm.begin(), perm.end(), randomGenerator);
+    std::vector<VertexQuery> queries;
+    for (size_t i = 0; i < numQueries; i++) {
+        queries.emplace_back(Vertex(perm[i]), Vertex(perm[numQueries + i]), timeDistribution(randomGenerator));
     }
     return queries;
 }

--- a/DataStructures/TripBased/DelayData.h
+++ b/DataStructures/TripBased/DelayData.h
@@ -184,6 +184,25 @@ public:
         }
     }
 
+    // Like filterShortcutGraph but skips annotation-based filters (MinOriginDelay,
+    // MaxOriginDelay), keeping only the physics-based feasibility check. Used as
+    // the source for stop-level projection so that annotation filtering cannot
+    // prevent a stop pair from appearing in the stop-level graph.
+    inline TransferGraph filterShortcutGraphForStopLevel() const noexcept {
+        TransferGraph result;
+        result.reserve(stopEventGraph.numVertices(), stopEventGraph.numEdges());
+        for (const Vertex fromStopEvent : stopEventGraph.vertices()) {
+            result.addVertex();
+            for (const Edge shortcut : stopEventGraph.edgesFrom(fromStopEvent)) {
+                const Vertex toStopEvent = stopEventGraph.get(ToVertex, shortcut);
+                const int travelTime = stopEventGraph.get(TravelTime, shortcut);
+                if (!isTransferFeasible(StopEventId(fromStopEvent), StopEventId(toStopEvent), travelTime)) continue;
+                result.addEdge(fromStopEvent, toStopEvent, stopEventGraph.edgeRecord(shortcut));
+            }
+        }
+        return result;
+    }
+
 private:
     inline RAPTOR::Data getDelayedRaptorData() const noexcept {
         RAPTOR::Data delayedData = data.raptorData;

--- a/DataStructures/TripBased/DelayUpdateData.h
+++ b/DataStructures/TripBased/DelayUpdateData.h
@@ -97,7 +97,7 @@ struct DelayQueryData {
     inline void update(RAPTOR::Data&& newRaptorData, const std::pair<TransferGraph, TransferGraph>&& filteredShortcuts) noexcept {
         const Order stopEventOrder = newRaptorData.rebuildRoutes();
         internalToOriginal = Permutation(stopEventOrder);
-        const Permutation originalToInternal(Construct::Invert, stopEventOrder);
+        originalToInternal = Permutation(Construct::Invert, stopEventOrder);
         tripData = Data(newRaptorData);
         tripData.stopEventGraph = filteredShortcuts.first;
         tripData.stopEventGraph.applyVertexPermutation(originalToInternal);
@@ -105,6 +105,7 @@ struct DelayQueryData {
 
     Data tripData;
     Permutation internalToOriginal;
+    Permutation originalToInternal;
 };
 
 }

--- a/Runnables/Commands/BenchmarkULTRA.h
+++ b/Runnables/Commands/BenchmarkULTRA.h
@@ -46,13 +46,15 @@ class CompareAllAlgorithms : public ParameterizedCommand {
 public:
     CompareAllAlgorithms(BasicShell& shell) :
         ParameterizedCommand(shell, "compareAllAlgorithms",
-            "Compares MR, TD-Dijkstra variants, JTS, TTN (FC/CST/BST), and ULTRA-CSA.") {
+            "Compares MR, TD-Dijkstra variants, JTS, TTN (FC/CST/BST), ULTRA-CSA, and optionally HL-RAPTOR/HL-CSA.") {
         addParameter("RAPTOR input file");
         addParameter("CSA input file");
         addParameter("Intermediate input file");
         addParameter("Core CH input file");
         addParameter("Full CH input file");
         addParameter("Number of queries");
+        addParameter("Out-hub file", "");
+        addParameter("In-hub file", "");
     }
 
     virtual void execute() noexcept {
@@ -458,6 +460,76 @@ public:
         std::cout << std::endl;
         std::cout << "Total time: " << String::msToString(ultraCSATime) << " (" << (ultraCSATime / n) << " ms/query)" << std::endl;
 
+        // ==================== ALGORITHM 13-14: HL-RAPTOR and HL-CSA (optional) ====================
+        const std::string outHubFile = getParameter("Out-hub file");
+        const std::string inHubFile = getParameter("In-hub file");
+        const bool runHL = !outHubFile.empty() && !inHubFile.empty();
+
+        std::vector<int> results_hl_raptor;
+        std::vector<int> results_hl_csa;
+        double hlRaptorTime = 0, hlCsaTime = 0;
+        double hlLoadTime = 0;
+        bool hl_raptor_correct = false;
+        bool hl_csa_correct = false;
+
+        if (runHL) {
+            std::cout << "\n========================================" << std::endl;
+            std::cout << "  13. HL-RAPTOR" << std::endl;
+            std::cout << "========================================\n" << std::endl;
+
+            Timer hlLoadTimer;
+            TransferGraph outHubs(outHubFile);
+            TransferGraph inHubs(inHubFile);
+            hlLoadTime = hlLoadTimer.elapsedMilliseconds();
+            std::cout << "Hub labels loaded in " << String::msToString(hlLoadTime) << std::endl;
+            std::cout << "  Out-hubs: " << outHubs.numVertices() << " vertices, "
+                      << outHubs.numEdges() << " edges" << std::endl;
+            std::cout << "  In-hubs:  " << inHubs.numVertices() << " vertices, "
+                      << inHubs.numEdges() << " edges" << std::endl;
+
+            RAPTOR::HLRAPTOR<RAPTOR::AggregateProfiler> hlRaptor(raptorData, outHubs, inHubs);
+
+            results_hl_raptor.reserve(n);
+            Timer hlrTimer;
+            for (size_t i = 0; i < queries.size(); ++i) {
+                const VertexQuery& query = queries[i];
+                hlRaptor.run(query.source, query.departureTime, query.target);
+                results_hl_raptor.push_back(hlRaptor.getEarliestArrivalTime(query.target));
+                if ((i + 1) % 100 == 0 || i + 1 == queries.size()) {
+                    std::cout << "\r  HL-RAPTOR: " << (i + 1) << "/" << n << " queries" << std::flush;
+                }
+            }
+            hlRaptorTime = hlrTimer.elapsedMilliseconds();
+            std::cout << std::endl;
+            std::cout << "Total time: " << String::msToString(hlRaptorTime) << " (" << (hlRaptorTime / n) << " ms/query)" << std::endl;
+
+            std::cout << "\n========================================" << std::endl;
+            std::cout << "  14. HL-CSA" << std::endl;
+            std::cout << "========================================\n" << std::endl;
+
+            CSA::Data hlCsaData = csaData;
+            TransferGraph emptyTransferGraph;
+            emptyTransferGraph.addVertices(csaData.transferGraph.numVertices());
+            Graph::move(std::move(emptyTransferGraph), hlCsaData.transferGraph);
+            hlCsaData.sortConnectionsAscending();
+
+            CSA::HLCSA<CSA::AggregateProfiler> hlCsa(hlCsaData, outHubs, inHubs);
+
+            results_hl_csa.reserve(n);
+            Timer hlcTimer;
+            for (size_t i = 0; i < queries.size(); ++i) {
+                const VertexQuery& query = queries[i];
+                hlCsa.run(query.source, query.departureTime, query.target);
+                results_hl_csa.push_back(hlCsa.getEarliestArrivalTime(query.target));
+                if ((i + 1) % 100 == 0 || i + 1 == queries.size()) {
+                    std::cout << "\r  HL-CSA: " << (i + 1) << "/" << n << " queries" << std::flush;
+                }
+            }
+            hlCsaTime = hlcTimer.elapsedMilliseconds();
+            std::cout << std::endl;
+            std::cout << "Total time: " << String::msToString(hlCsaTime) << " (" << (hlCsaTime / n) << " ms/query)" << std::endl;
+        }
+
         // ==================== PREPROCESSING SUMMARY ====================
         std::cout << "\n========================================" << std::endl;
         std::cout << "       PREPROCESSING TIMES" << std::endl;
@@ -484,6 +556,9 @@ public:
         std::cout << "Bucket-CH (FC):              " << String::msToString(bucketFCBuildTime) << std::endl;
         std::cout << "Bucket-CH (CST):             " << String::msToString(bucketCSTBuildTime) << std::endl;
         std::cout << "Bucket-CH (BST):             " << String::msToString(bucketBSTBuildTime) << std::endl;
+        if (runHL) {
+            std::cout << "Hub label load:              " << String::msToString(hlLoadTime) << std::endl;
+        }
         std::cout << "Total preprocessing time:    " << String::msToString(totalPreprocessingTime) << std::endl;
 
         // ==================== CORRECTNESS COMPARISON ====================
@@ -563,6 +638,10 @@ public:
         bool bst_corech_correct = compareResults("TTN-BST (Core-CH)", results_bst_corech, true);
         bool bst_bucketch_correct = compareResults("TTN-BST (Bucket-CH)", results_bst_bucketch, true);
         bool ultra_csa_correct = compareResults("ULTRA-CSA (Bucket-CH)", results_ultra_csa, false);
+        if (runHL) {
+            hl_raptor_correct = compareResults("HL-RAPTOR", results_hl_raptor, false);
+            hl_csa_correct = compareResults("HL-CSA", results_hl_csa, false);
+        }
 
         // ==================== PERFORMANCE SUMMARY ====================
         std::cout << "\n========================================" << std::endl;
@@ -598,6 +677,10 @@ public:
         printRow("TTN-BST (Core-CH)", bstCoreCHTime, bst_corech_correct);
         printRow("TTN-BST (Bucket-CH)", bstBucketCHTime, bst_bucketch_correct);
         printRow("ULTRA-CSA (Bucket-CH)", ultraCSATime, ultra_csa_correct);
+        if (runHL) {
+            printRow("HL-RAPTOR", hlRaptorTime, hl_raptor_correct);
+            printRow("HL-CSA", hlCsaTime, hl_csa_correct);
+        }
 
         std::cout << "└─────────────────────────────────┴────────────┴───────────┴─────────┘" << std::endl;
 
@@ -656,6 +739,8 @@ public:
         if (bst_corech_correct) correctAlgos.push_back({"TTN-BST (Core-CH)", bstCoreCHTime});
         if (bst_bucketch_correct) correctAlgos.push_back({"TTN-BST (Bucket-CH)", bstBucketCHTime});
         if (ultra_csa_correct) correctAlgos.push_back({"ULTRA-CSA (Bucket-CH)", ultraCSATime});
+        if (runHL && hl_raptor_correct) correctAlgos.push_back({"HL-RAPTOR", hlRaptorTime});
+        if (runHL && hl_csa_correct) correctAlgos.push_back({"HL-CSA", hlCsaTime});
 
         auto fastest = std::min_element(correctAlgos.begin(), correctAlgos.end(),
             [](const auto& a, const auto& b) { return a.second < b.second; });

--- a/Runnables/Commands/CH.h
+++ b/Runnables/Commands/CH.h
@@ -10,6 +10,7 @@
 #include "../../DataStructures/RAPTOR/Data.h"
 
 #include "../../Algorithms/CH/CH.h"
+#include "../../Algorithms/CH/HubLabelExtractor.h"
 #include "../../Algorithms/CH/Preprocessing/CHBuilder.h"
 #include "../../Algorithms/CH/Preprocessing/BidirectionalWitnessSearch.h"
 #include "../../Shell/Shell.h"
@@ -172,3 +173,33 @@ private:
         data.serialize(getParameter("Network output file"));
     }
 };
+
+class ExtractHubLabels : public ParameterizedCommand {
+
+public:
+    ExtractHubLabels(BasicShell& shell) :
+        ParameterizedCommand(shell, "extractHubLabels", "Extracts hub labels from a full CH for use with HLRAPTOR/HLCSA.") {
+        addParameter("CH input file");
+        addParameter("Out-hub output file");
+        addParameter("In-hub output file");
+    }
+
+    virtual void execute() noexcept {
+        Timer totalTimer;
+
+        std::cout << "Loading CH..." << std::endl;
+        CH::CH ch(getParameter("CH input file"));
+        std::cout << "CH: " << String::prettyInt(ch.numVertices()) << " vertices, "
+                  << String::prettyInt(ch.numEdges()) << " edges" << std::endl;
+
+        CH::HubLabelExtractor extractor(ch);
+        extractor.run();
+
+        std::cout << "\nWriting out-hub labels..." << std::endl;
+        extractor.getOutHubs().writeBinary(getParameter("Out-hub output file"));
+        std::cout << "Writing in-hub labels..." << std::endl;
+        extractor.getInHubs().writeBinary(getParameter("In-hub output file"));
+        std::cout << "\nTotal preprocessing time (including I/O): " << String::msToString(totalTimer.elapsedMilliseconds()) << std::endl;
+    }
+};
+

--- a/Runnables/Commands/CH.h
+++ b/Runnables/Commands/CH.h
@@ -1,6 +1,8 @@
+#include <fstream>
 #include <iostream>
-#include <vector>
+#include <sstream>
 #include <string>
+#include <vector>
 #include <random>
 
 #include "../../Helpers/MultiThreading.h"
@@ -200,6 +202,73 @@ public:
         std::cout << "Writing in-hub labels..." << std::endl;
         extractor.getInHubs().writeBinary(getParameter("In-hub output file"));
         std::cout << "\nTotal preprocessing time (including I/O): " << String::msToString(totalTimer.elapsedMilliseconds()) << std::endl;
+    }
+};
+
+class ImportHubLabels : public ParameterizedCommand {
+
+public:
+    ImportHubLabels(BasicShell& shell) :
+        ParameterizedCommand(shell, "importHubLabels",
+            "Imports hub labels from lviennot/hub-labeling text format into TransferGraph binary files.") {
+        addParameter("Hub label text file");
+        addParameter("Number of vertices");
+        addParameter("Out-hub output file");
+        addParameter("In-hub output file");
+    }
+
+    virtual void execute() noexcept {
+        const std::string inputFile = getParameter("Hub label text file");
+        const size_t numVertices = getParameter<size_t>("Number of vertices");
+
+        std::ifstream is(inputFile);
+        Assert(is.is_open(), "Cannot open hub label file: " << inputFile);
+
+        DynamicTransferGraph outGraph, inGraph;
+        outGraph.addVertices(numVertices);
+        inGraph.addVertices(numVertices);
+
+        size_t outCount = 0, inCount = 0;
+        std::string line;
+        while (std::getline(is, line)) {
+            if (line.empty()) continue;
+            char type = line[0];
+            if (type != 'o' && type != 'i') continue;
+
+            std::istringstream ss(line.substr(2));
+            size_t a, b;
+            int64_t dist;
+            if (!(ss >> a >> b >> dist)) continue;
+
+            if (type == 'o') {
+                // o vertex hub distance → outHubs: vertex → hub
+                outGraph.addEdge(Vertex(a), Vertex(b)).set(TravelTime, static_cast<int>(dist));
+                outCount++;
+            } else {
+                // i hub vertex distance → inHubs: vertex → hub
+                inGraph.addEdge(Vertex(b), Vertex(a)).set(TravelTime, static_cast<int>(dist));
+                inCount++;
+            }
+        }
+        is.close();
+
+        std::cout << "Parsed " << outCount << " out-hub edges, "
+                  << inCount << " in-hub edges" << std::endl;
+
+        TransferGraph outHubs, inHubs;
+        Graph::move(std::move(outGraph), outHubs);
+        Graph::move(std::move(inGraph), inHubs);
+
+        double avgOut = static_cast<double>(outCount) / numVertices;
+        double avgIn = static_cast<double>(inCount) / numVertices;
+        std::cout << "Out-hubs: " << outHubs.numVertices() << " vertices, "
+                  << outHubs.numEdges() << " edges (avg " << avgOut << ")" << std::endl;
+        std::cout << "In-hubs:  " << inHubs.numVertices() << " vertices, "
+                  << inHubs.numEdges() << " edges (avg " << avgIn << ")" << std::endl;
+
+        outHubs.writeBinary(getParameter("Out-hub output file"));
+        inHubs.writeBinary(getParameter("In-hub output file"));
+        std::cout << "Hub labels written." << std::endl;
     }
 };
 

--- a/Runnables/Commands/DelayExperiments.h
+++ b/Runnables/Commands/DelayExperiments.h
@@ -359,7 +359,8 @@ inline StopId stopOfEvent(const TripBased::Data& tbData,
 
 inline Intermediate::TransferGraph convertShortcutsToStopGraph(
         const RAPTOR::Data& raptorData,
-        const TripBased::Data& tbData) noexcept {
+        const TripBased::Data& tbData,
+        const TransferGraph& seg) noexcept {
     const size_t numStops = raptorData.numberOfStops();
 
     Intermediate::TransferGraph graph;
@@ -370,7 +371,6 @@ inline Intermediate::TransferGraph convertShortcutsToStopGraph(
             raptorData.transferGraph.get(Coordinates, Vertex(i)));
     }
 
-    const auto& seg = tbData.stopEventGraph;
     for (Vertex from(0); from < seg.numVertices(); from++) {
         if (static_cast<size_t>(from) >= tbData.numberOfStopEvents()) continue;
         const StopId fromStop = stopOfEvent(tbData, StopEventId(from));
@@ -399,6 +399,12 @@ inline Intermediate::TransferGraph convertShortcutsToStopGraph(
 
     graph.packEdges();
     return graph;
+}
+
+inline Intermediate::TransferGraph convertShortcutsToStopGraph(
+        const RAPTOR::Data& raptorData,
+        const TripBased::Data& tbData) noexcept {
+    return convertShortcutsToStopGraph(raptorData, tbData, tbData.stopEventGraph);
 }
 
 inline RAPTOR::Data buildShortcutRaptorData(
@@ -1242,9 +1248,14 @@ public:
             tbResults.emplace_back(tbAlgorithm.getArrivals());
 
             // --- Convert event shortcuts to stop-level graph ---
+            // Use physics-only filtering so that annotation-based filters
+            // cannot prevent a stop pair from appearing in the stop-level graph.
+            TransferGraph stopLevelSource = delayData.filterShortcutGraphForStopLevel();
+            const Permutation& origToInt = queryData.originalToInternal;
+            stopLevelSource.applyVertexPermutation(origToInt);
             Intermediate::TransferGraph shortcutGraph =
                 DelayHelpers::convertShortcutsToStopGraph(
-                    queryData.tripData.raptorData, queryData.tripData);
+                    queryData.tripData.raptorData, queryData.tripData, stopLevelSource);
 
             // --- ULTRA-RAPTOR ---
             RAPTOR::Data shortcutRaptorData =
@@ -1362,12 +1373,15 @@ public:
         //     ULTRA-RAPTOR, ULTRA-RAPTOR (EP))
         // =================================================================
         Timer conversionTimer;
+        TransferGraph stopLevelSource = delayUpdater.getDelayData().filterShortcutGraphForStopLevel();
+        const Permutation& origToInt = queryData.originalToInternal;
+        stopLevelSource.applyVertexPermutation(origToInt);
         Intermediate::TransferGraph shortcutGraph =
             DelayHelpers::convertShortcutsToStopGraph(
-                queryData.tripData.raptorData, queryData.tripData);
+                queryData.tripData.raptorData, queryData.tripData, stopLevelSource);
         const double conversionTimeMs = conversionTimer.elapsedMilliseconds();
-        std::cout << "  Shortcut conversion: "
-                  << queryData.tripData.stopEventGraph.numEdges()
+        std::cout << "  Shortcut conversion (physics-only): "
+                  << stopLevelSource.numEdges()
                   << " stop-event edges -> "
                   << shortcutGraph.numEdges()
                   << " stop edges ("

--- a/Runnables/Commands/DelayExperiments.h
+++ b/Runnables/Commands/DelayExperiments.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <iostream>
@@ -27,7 +28,9 @@
 #include "../../DataStructures/CSA/Data.h"
 
 #include "../../Algorithms/RAPTOR/DijkstraRAPTOR.h"
+#include "../../Algorithms/RAPTOR/HLRAPTOR.h"
 #include "../../Algorithms/RAPTOR/InitialTransfers.h"
+#include "../../Algorithms/CSA/HLCSA.h"
 #include "../../Algorithms/TripBased/Preprocessing/DelayUpdater.h"
 #include "../../Algorithms/TripBased/Query/Query.h"
 
@@ -1332,7 +1335,7 @@ public:
     MeasureDelayULTRACSAQueryPerformance(BasicShell& shell) :
         ParameterizedCommand(shell, "measureDelayULTRACSAQueryPerformance",
             "Measures query performance of Delay-ULTRA-CSA, ULTRA-RAPTOR, "
-            "ULTRA-RAPTOR (EP), ULTRA-TB, MR, TD-Dijkstra, and TAD.") {
+            "ULTRA-RAPTOR (EP), ULTRA-TB, MR, TD-Dijkstra, TAD, HL-RAPTOR, and HL-CSA.") {
         addParameter("Dijkstra RAPTOR data");
         addParameter("Trip-Based data");
         addParameter("Core CH data");
@@ -1341,6 +1344,9 @@ public:
         addParameter("Number of queries");
         addParameter("Start time", "14:00:00");
         addParameter("End time", "15:00:00");
+        addParameter("Out-hub file", "");
+        addParameter("In-hub file", "");
+        addParameter("Without replacement", "false");
     }
 
     virtual void execute() noexcept {
@@ -1470,12 +1476,58 @@ public:
             tdGraphClassic, delayedRaptorData.numberOfStops(), &bucketCH);
 
         // =================================================================
+        //  8c. HL-RAPTOR and HL-CSA (optional, when hub files provided)
+        // =================================================================
+        const std::string outHubFile = getParameter("Out-hub file");
+        const std::string inHubFile = getParameter("In-hub file");
+        const bool runHL = !outHubFile.empty() && !inHubFile.empty();
+
+        // Declare pointers — constructed only when hub files are provided
+        std::unique_ptr<TransferGraph> outHubs, inHubs;
+        std::unique_ptr<RAPTOR::HLRAPTOR<RAPTOR::AggregateProfiler>> hlRaptor;
+        std::unique_ptr<CSA::HLCSA<CSA::AggregateProfiler>> hlCsa;
+        std::unique_ptr<CSA::Data> hlCsaData;
+        std::unique_ptr<RAPTOR::Data> hlRaptorData;
+
+        if (runHL) {
+            std::cout << "\nLoading hub labels..." << std::endl;
+            outHubs = std::make_unique<TransferGraph>(outHubFile);
+            inHubs = std::make_unique<TransferGraph>(inHubFile);
+            std::cout << "  Out-hubs: " << outHubs->numVertices() << " vertices, "
+                      << outHubs->numEdges() << " edges" << std::endl;
+            std::cout << "  In-hubs:  " << inHubs->numVertices() << " vertices, "
+                      << inHubs->numEdges() << " edges" << std::endl;
+
+            // HL-RAPTOR: same delayed timetable as MR, but transfers via hub labels
+            hlRaptorData = std::make_unique<RAPTOR::Data>(delayedRaptorData);
+            hlRaptorData->useImplicitDepartureBufferTimes();
+            hlRaptor = std::make_unique<RAPTOR::HLRAPTOR<RAPTOR::AggregateProfiler>>(
+                *hlRaptorData, *outHubs, *inHubs);
+
+            // HL-CSA: build CSA data with empty transfer graph (HL handles transfers)
+            Intermediate::TransferGraph emptyTransferGraph;
+            emptyTransferGraph.addVertices(
+                queryData.tripData.raptorData.transferGraph.numVertices());
+            hlCsaData = std::make_unique<CSA::Data>(
+                DelayHelpers::buildCSADataWithShortcuts(
+                    queryData.tripData.raptorData, std::move(emptyTransferGraph)));
+            hlCsaData->sortConnectionsAscending();
+            hlCsa = std::make_unique<CSA::HLCSA<CSA::AggregateProfiler>>(
+                *hlCsaData, *outHubs, *inHubs);
+        }
+
+        // =================================================================
         //  9. Generate random queries
         // =================================================================
         const size_t n = getParameter<size_t>("Number of queries");
-        const std::vector<VertexQuery> queries =
-            generateRandomVertexQueries(bucketCH.numVertices(), n,
-                                        startTime, endTime);
+        const bool withoutReplacement = getParameter<bool>("Without replacement");
+        const std::vector<VertexQuery> queries = withoutReplacement
+            ? generateRandomVertexQueriesWithoutReplacement(
+                  bucketCH.numVertices(), n, startTime, endTime)
+            : generateRandomVertexQueries(
+                  bucketCH.numVertices(), n, startTime, endTime);
+        std::cout << "  Query mode: " << (withoutReplacement ? "without" : "with")
+                  << " replacement" << std::endl;
 
         // =================================================================
         //  10. Run all algorithms
@@ -1535,6 +1587,21 @@ public:
         const auto csaResults = runCSAQueries(queries, delayCSA);
         const double csaTime = timer.elapsedMilliseconds();
 
+        // HL algorithms (only when hub files provided)
+        double hlrTime = 0, hlcTime = 0;
+        std::vector<std::vector<RAPTOR::ArrivalLabel>> hlrResults, hlcResults;
+        if (runHL) {
+            std::cout << "\n--- HL-RAPTOR ---" << std::endl;
+            timer.restart();
+            hlrResults = runQueries(queries, *hlRaptor);
+            hlrTime = timer.elapsedMilliseconds();
+
+            std::cout << "\n--- HL-CSA ---" << std::endl;
+            timer.restart();
+            hlcResults = runHLCSAQueries(queries, *hlCsa);
+            hlcTime = timer.elapsedMilliseconds();
+        }
+
         // =================================================================
         //  11. Timing summary
         // =================================================================
@@ -1554,6 +1621,10 @@ public:
         printTime("ULTRA-RAPTOR total:", urTime);
         printTime("ULTRA-RAPTOR (EP) total:", urpTime);
         printTime("Delay-ULTRA-CSA total:", csaTime);
+        if (runHL) {
+            printTime("HL-RAPTOR total:", hlrTime);
+            printTime("HL-CSA total:", hlcTime);
+        }
 
         std::cout << std::setprecision(2);
         auto printSpeedup = [&](const char* label, double num, double den) {
@@ -1570,6 +1641,10 @@ public:
         printSpeedup("Speedup CSA vs URP:", urpTime, csaTime);
         printSpeedup("Speedup TAD vs MR:", mrTime, tadTime);
         printSpeedup("Speedup TD-Dijkstra vs MR:", mrTime, tdTime);
+        if (runHL) {
+            printSpeedup("Speedup HL-RAPTOR vs MR:", mrTime, hlrTime);
+            printSpeedup("Speedup HL-CSA vs MR:", mrTime, hlcTime);
+        }
 
         // =================================================================
         //  12. Quality comparisons
@@ -1594,6 +1669,15 @@ public:
 
         std::cout << "\n=== Quality: MR vs TD-Dijkstra (Classic) ===" << std::endl;
         DelayHelpers::printTDQuality(queries, dijkstraResults, tdResults);
+
+        if (runHL) {
+            std::cout << "\n=== Quality: MR vs HL-RAPTOR ===" << std::endl;
+            const QueryStatistics hlrStats(queries, dijkstraResults, hlrResults);
+            std::cout << hlrStats << std::endl;
+
+            std::cout << "=== Quality: MR vs HL-CSA ===" << std::endl;
+            DelayHelpers::printCSAQuality(queries, dijkstraResults, hlcResults);
+        }
     }
 
 private:
@@ -1628,6 +1712,27 @@ private:
             results.emplace_back(algorithm.getArrivals());
             progress++;
         }
+        return results;
+    }
+
+    template<typename HLCSA_ALGO>
+    inline std::vector<std::vector<RAPTOR::ArrivalLabel>> runHLCSAQueries(
+            const std::vector<VertexQuery>& queries,
+            HLCSA_ALGO& algorithm) const noexcept {
+        Progress progress(queries.size());
+        std::vector<std::vector<RAPTOR::ArrivalLabel>> results;
+        results.reserve(queries.size());
+        for (const VertexQuery& query : queries) {
+            algorithm.run(query.source, query.departureTime, query.target);
+            std::vector<RAPTOR::ArrivalLabel> arrivals;
+            const int arr = algorithm.getEarliestArrivalTime(query.target);
+            if (arr < never) {
+                arrivals.emplace_back(arr, 1);
+            }
+            results.emplace_back(std::move(arrivals));
+            progress++;
+        }
+        algorithm.getProfiler().printStatistics();
         return results;
     }
 };

--- a/Runnables/Commands/DelayExperiments.h
+++ b/Runnables/Commands/DelayExperiments.h
@@ -1182,13 +1182,16 @@ class MeasureDelayQueryCoverage : public ParameterizedCommand {
 public:
     MeasureDelayQueryCoverage(BasicShell& shell) :
         ParameterizedCommand(shell, "measureDelayQueryCoverage",
-            "Evaluates per-query coverage of TB, RAPTOR, RAPTOR-EP, and CSA "
+            "Evaluates per-query coverage of TB, RAPTOR, RAPTOR-EP, CSA, "
+            "and optionally HL-RAPTOR/HL-CSA "
             "using hypothetical mode (all replacement shortcuts known in advance).") {
         addParameter("Trip-Based data");
         addParameter("Bucket CH data");
         addParameter("Query input data");
         addParameter("Update log file");
         addParameter("Number of queries", "0");
+        addParameter("Out-hub file", "");
+        addParameter("In-hub file", "");
     }
 
     virtual void execute() noexcept {
@@ -1225,16 +1228,48 @@ public:
                   << " affected queries." << std::endl;
 
         // =================================================================
+        //  3b. Load hub labels (optional)
+        // =================================================================
+        const std::string outHubFile = getParameter("Out-hub file");
+        const std::string inHubFile = getParameter("In-hub file");
+        const bool runHL = !outHubFile.empty() && !inHubFile.empty();
+
+        std::unique_ptr<TransferGraph> outHubs, inHubs;
+        TransferGraph prebuiltReverseInHubs;
+        if (runHL) {
+            std::cout << "Loading hub labels..." << std::endl;
+            outHubs = std::make_unique<TransferGraph>(outHubFile);
+            inHubs = std::make_unique<TransferGraph>(inHubFile);
+            std::cout << "  Out-hubs: " << outHubs->numVertices() << " vertices, "
+                      << outHubs->numEdges() << " edges" << std::endl;
+            std::cout << "  In-hubs:  " << inHubs->numVertices() << " vertices, "
+                      << inHubs->numEdges() << " edges" << std::endl;
+            std::cout << "Pre-sorting hub graphs and building reverseInHubs..." << std::endl;
+            outHubs->sortEdges(TravelTime);
+            inHubs->sortEdges(TravelTime);
+            RAPTOR::Data tempData = queryData.tripData.raptorData;
+            tempData.useImplicitDepartureBufferTimes();
+            prebuiltReverseInHubs = RAPTOR::HLRAPTOR<RAPTOR::NoProfiler>::buildReverseInHubs(tempData, *inHubs);
+            std::cout << "  reverseInHubs: " << prebuiltReverseInHubs.numEdges() << " edges" << std::endl;
+        }
+
+        // =================================================================
         //  4. Per-query coverage loop
         // =================================================================
         std::vector<std::vector<RAPTOR::ArrivalLabel>> tbResults;
         std::vector<std::vector<RAPTOR::ArrivalLabel>> raptorResults;
         std::vector<std::vector<RAPTOR::ArrivalLabel>> raptorEPResults;
         std::vector<std::vector<RAPTOR::ArrivalLabel>> csaResults;
+        std::vector<std::vector<RAPTOR::ArrivalLabel>> hlrResults;
+        std::vector<std::vector<RAPTOR::ArrivalLabel>> hlcResults;
         tbResults.reserve(queries.size());
         raptorResults.reserve(queries.size());
         raptorEPResults.reserve(queries.size());
         csaResults.reserve(queries.size());
+        if (runHL) {
+            hlrResults.reserve(queries.size());
+            hlcResults.reserve(queries.size());
+        }
 
         Progress progress(queries.size());
         for (size_t i = 0; i < queries.size(); i++) {
@@ -1287,6 +1322,35 @@ public:
                              queries[i].target);
             csaResults.emplace_back(csaAlgorithm.getArrivals());
 
+            // --- HL-RAPTOR and HL-CSA (optional) ---
+            if (runHL) {
+                RAPTOR::Data hlRaptorData = queryData.tripData.raptorData;
+                hlRaptorData.useImplicitDepartureBufferTimes();
+                // Zero-copy constructor: references pre-sorted hub graphs, no 26M edge copy
+                RAPTOR::HLRAPTOR<RAPTOR::NoProfiler> hlRaptorAlg(
+                    hlRaptorData, *outHubs, *inHubs, prebuiltReverseInHubs);
+                hlRaptorAlg.run(queries[i].source, queries[i].departureTime,
+                                queries[i].target);
+                hlrResults.emplace_back(hlRaptorAlg.getArrivals());
+
+                Intermediate::TransferGraph emptyTransferGraph;
+                emptyTransferGraph.addVertices(
+                    queryData.tripData.raptorData.transferGraph.numVertices());
+                CSA::Data hlCsaData = DelayHelpers::buildCSADataWithShortcuts(
+                    queryData.tripData.raptorData, std::move(emptyTransferGraph));
+                hlCsaData.sortConnectionsAscending();
+                CSA::HLCSA<CSA::NoProfiler> hlCsaAlg(
+                    hlCsaData, *outHubs, *inHubs);
+                hlCsaAlg.run(queries[i].source, queries[i].departureTime,
+                             queries[i].target);
+                std::vector<RAPTOR::ArrivalLabel> hlcArrivals;
+                const int hlcArr = hlCsaAlg.getEarliestArrivalTime(queries[i].target);
+                if (hlcArr < never) {
+                    hlcArrivals.emplace_back(hlcArr, 1);
+                }
+                hlcResults.emplace_back(std::move(hlcArrivals));
+            }
+
             progress++;
         }
 
@@ -1311,6 +1375,17 @@ public:
         std::cout << "=== Delay-ULTRA-CSA Coverage ===" << std::endl;
         DelayHelpers::printCSAQuality(queries,
             queryInputData.failedQueryResults, csaResults);
+
+        if (runHL) {
+            std::cout << "\n=== HL-RAPTOR Coverage ===" << std::endl;
+            const QueryStatistics hlrStats(queries,
+                queryInputData.failedQueryResults, hlrResults);
+            std::cout << hlrStats << std::endl;
+
+            std::cout << "=== HL-CSA Coverage ===" << std::endl;
+            DelayHelpers::printCSAQuality(queries,
+                queryInputData.failedQueryResults, hlcResults);
+        }
     }
 };
 

--- a/Runnables/Commands/NetworkIO.h
+++ b/Runnables/Commands/NetworkIO.h
@@ -459,3 +459,33 @@ private:
         }
     };
 };
+
+class ExportGraphEdgeList : public ParameterizedCommand {
+
+public:
+    ExportGraphEdgeList(BasicShell& shell) :
+        ParameterizedCommand(shell, "exportGraphEdgeList",
+            "Exports a TransferGraph as a plain text edge list (0-indexed: src dst weight).") {
+        addParameter("Graph input file");
+        addParameter("Output text file");
+    }
+
+    virtual void execute() noexcept {
+        TransferGraph graph(getParameter("Graph input file"));
+        Graph::printInfo(graph);
+
+        const std::string outputFile = getParameter("Output text file");
+        std::ofstream os(outputFile);
+        Assert(os.is_open(), "Cannot open output file: " << outputFile);
+
+        for (const auto [edge, from] : graph.edgesWithFromVertex()) {
+            os << static_cast<size_t>(from) << " "
+               << static_cast<size_t>(graph.get(ToVertex, edge)) << " "
+               << graph.get(TravelTime, edge) << "\n";
+        }
+        os.close();
+
+        std::cout << "Exported " << graph.numVertices() << " vertices, "
+                  << graph.numEdges() << " edges to " << outputFile << std::endl;
+    }
+};

--- a/Runnables/ULTRA.cpp
+++ b/Runnables/ULTRA.cpp
@@ -19,6 +19,7 @@ int main(int argc, char** argv) {
     ::Shell::Shell shell;
     new BuildCH(shell);
     new BuildCoreCH(shell);
+    new ExtractHubLabels(shell);
 
     //Preprocessing
     new BuildTDGraph(shell);

--- a/Runnables/ULTRA.cpp
+++ b/Runnables/ULTRA.cpp
@@ -1,4 +1,5 @@
 #include "Commands/CH.h"
+#include "Commands/NetworkIO.h"
 #include "Commands/ULTRAPreprocessing.h"
 
 #include "Commands/BenchmarkULTRA.h"
@@ -20,6 +21,8 @@ int main(int argc, char** argv) {
     new BuildCH(shell);
     new BuildCoreCH(shell);
     new ExtractHubLabels(shell);
+    new ImportHubLabels(shell);
+    new ExportGraphEdgeList(shell);
 
     //Preprocessing
     new BuildTDGraph(shell);


### PR DESCRIPTION
## Summary
- Add HL-RAPTOR and HL-CSA baseline algorithms to the delay benchmark suite
- Add lviennot hub label import/export commands (`importHubLabels`, `exportGraphEdgeList`)
- Optimize HL coverage loop in `HubLabelExtractor`
- Add `extractHubLabels` command for CH-based hub label extraction

Depends on #12 (includes its commit).

## Changes
- `Algorithms/CH/HubLabelExtractor.h`: new hub label extraction from CH
- `Algorithms/RAPTOR/HLRAPTOR.h`: extend HL-RAPTOR with profiling and delay support
- `Runnables/Commands/CH.h`: add `extractHubLabels` command
- `Runnables/Commands/NetworkIO.h`: add `importHubLabels`, `exportGraphEdgeList`
- `Runnables/Commands/DelayExperiments.h`: add HL-based delay query benchmarks
- `Runnables/Commands/BenchmarkULTRA.h`: add HL-RAPTOR query commands